### PR TITLE
add installer for standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+"standard": {
+  "ignore": [
+    "/backend/node_modules/"
+  ]
+}

--- a/team_members.md
+++ b/team_members.md
@@ -12,3 +12,6 @@ Jonathan Alkalai - alkalai2
 see git branch history : `git log --oneline --decorate --graph --all`
 
 [Editing Markdown (.md) Files](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#links)
+
+# Team Members
+ccmarte2 - Charlie Martell


### PR DESCRIPTION
This simple script ensures git is installed, npm (node package manager) is installed, and if so installs js standard style checker. It then creates a git hook to check all javascript files for any javascript code not following the standard that has staged changes for commit. NOTE: this tries to install npm and git based on your os / comp arch but it is not comprehensive and for windows/linux may cause errors. I put in comments referencing how to do it manually aswell but I believe it should work on debian based linux systems + windows (if they use chocolately package manager).